### PR TITLE
enable mysql and postgresql

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ compileTestKotlin {
 
 repositories {
     jcenter()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -39,7 +40,10 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: springBootVersion
 
     // rdbms
+    compile group: 'com.zaxxer', name: 'HikariCP', version: '2.7.7'
     compile group: 'com.h2database', name: 'h2', version: '1.4.196'
+    compile group: 'mysql', name: 'mysql-connector-java', version: '6.0.6'
+    compile group: 'org.postgresql', name: 'postgresql', version: '42.2.1'
 
     // kotlin
     compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8', version: kotlinVersion

--- a/infra/rdbms/docker-compose.yml
+++ b/infra/rdbms/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  mysql:
+    image: mysql
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: fkdlqmfjfl
+      MYSQL_DATABASE: library
+      MYSQL_USER: library
+      MYSQL_PASSWORD: fkdlqmfjfl
+
+  postgres:
+    image: postgres
+    ports:
+      - "5432:5432"
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: fkdlqmfjfl
+      POSTGRES_DB: library
+      POSTGRES_USER: library

--- a/src/main/kotlin/com/mark/library/service/LoanService.kt
+++ b/src/main/kotlin/com/mark/library/service/LoanService.kt
@@ -2,7 +2,6 @@ package com.mark.library.service
 
 import com.mark.library.domain.*
 import org.springframework.stereotype.Service
-import javax.annotation.PostConstruct
 
 @Service
 class LoanService(
@@ -10,30 +9,6 @@ class LoanService(
         private val memberRepo: MemberRepository,
         private val loanRepo: LoanRepository
 ) {
-    @PostConstruct
-    fun init() {
-        bookRepo.save(
-                listOf(
-                        Book(title = "선과 모터사이클 관리술: 가치에 대한 탐구",
-                                author = "로버트 M. 피어시그",
-                                catalog = "843",
-                                count = 3),
-                        Book(title = "제3인류",
-                                author = "베르나르 베르베르",
-                                catalog = "863",
-                                count = 1)
-                )
-        )
-
-        memberRepo.save(
-                listOf(
-                        Member(email = "member1@library.gov"),
-                        Member(email = "member2@library.gov"),
-                        Member(email = "member3@library.gov")
-                )
-        )
-    }
-
     fun checkOut(memberId: Long, bookId: Long): Loan {
         val member = memberRepo.findOne(memberId)
                 ?: throw IllegalArgumentException("member $memberId not found")

--- a/src/main/resources/application-mysql.yml
+++ b/src/main/resources/application-mysql.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    type: com.zaxxer.hikari.HikariDataSource
+    url: jdbc:mysql://localhost:3306/library?useSSL=false&autoReconnect=true&autoReconnectForPools=true&useUnicode=true&characterEncoding=UTF-8&serverTimezone=UTC
+    username: library
+    password: fkdlqmfjfl

--- a/src/main/resources/application-postgresql.yml
+++ b/src/main/resources/application-postgresql.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    type: com.zaxxer.hikari.HikariDataSource
+    url: jdbc:postgresql://localhost:5432/library
+    username: library
+    password: fkdlqmfjfl

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,10 +3,16 @@ logging:
     org:
       springframework:
         security: DEBUG
-      hibernate:
-       SQL: DEBUG
 
 keystone:
   endpoint: http://127.0.0.1:5000/v3
   domain: default
   project: library
+
+spring:
+  profiles:
+    active: mysql
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: update


### PR DESCRIPTION
mysql과 postgresql지원을 추가합니다. backend는 resources/application.yml파일의 active profile로 지정합니다.
```
spring:
  profiles:
    active: postgresql
```

mysql은 localhost:3306/library로, localhost:5432/library로 접속합니다.

### 프레임워크
* hikariCP : rdbms connection pool

### 기타
localhost에 mysql과 postgresql을 구동하는 docker-compose스크립트를 추가하였습니다.
